### PR TITLE
Bugfix/06 02 2025 tutorial dungeon timer

### DIFF
--- a/Assets/Scenes/Dungeon Exploration/Story1-1.unity
+++ b/Assets/Scenes/Dungeon Exploration/Story1-1.unity
@@ -17363,7 +17363,7 @@ MonoBehaviour:
   enemyPrefab: {fileID: 3792211553574827304, guid: 2670fc41b8eb4be43a991b3aa88abdf3, type: 3}
   spawnPoints:
   - {fileID: 671680702}
-  timeLimit: 120
+  timeLimit: 10
   totalEnemiesToDefeat: 8
   timerText: {fileID: 525903445}
   enemiesDefeatedText: {fileID: 450888955}
@@ -17372,6 +17372,7 @@ MonoBehaviour:
   winPanel: {fileID: 1972924473}
   challengePanel: {fileID: 1718431583}
   goldRewardPanel: {fileID: 2073638236}
+  gameOverPanel: {fileID: 538420370}
   StoryPanelEnd: {fileID: 2057181058}
   congratulationsPanel: {fileID: 1930445722}
   continueButton: {fileID: 508395970}

--- a/Assets/Scenes/Dungeon Exploration/Story1-1.unity
+++ b/Assets/Scenes/Dungeon Exploration/Story1-1.unity
@@ -17363,7 +17363,7 @@ MonoBehaviour:
   enemyPrefab: {fileID: 3792211553574827304, guid: 2670fc41b8eb4be43a991b3aa88abdf3, type: 3}
   spawnPoints:
   - {fileID: 671680702}
-  timeLimit: 10
+  timeLimit: 80
   totalEnemiesToDefeat: 8
   timerText: {fileID: 525903445}
   enemiesDefeatedText: {fileID: 450888955}

--- a/Assets/Scripts/Dungeon Controller/DungeonGameController.cs
+++ b/Assets/Scripts/Dungeon Controller/DungeonGameController.cs
@@ -24,6 +24,7 @@ public class DungeonGameController : MonoBehaviour
     public GameObject winPanel;         // Reference to the Win Panel (UI)
     public GameObject challengePanel;   // Reference to the Dungeon Challenge Panel (UI)
     public GameObject goldRewardPanel;  // Reference to the Gold Reward Panel (UI)
+    public GameObject gameOverPanel; // Reference to the Game Over Panel
 
     public GameObject StoryPanelEnd;
 
@@ -157,6 +158,7 @@ public class DungeonGameController : MonoBehaviour
         else
         {
             Debug.Log("Game over! Time's up or enemies not defeated.");
+            gameOverPanel.SetActive(true);
         }
     }
 

--- a/Assets/Scripts/Dungeon Controller/DungeonGameController.cs
+++ b/Assets/Scripts/Dungeon Controller/DungeonGameController.cs
@@ -158,7 +158,8 @@ public class DungeonGameController : MonoBehaviour
         else
         {
             Debug.Log("Game over! Time's up or enemies not defeated.");
-            gameOverPanel.SetActive(true);
+            gameOverPanel.SetActive(true); // shows game over screen
+            StartCoroutine(FreezeAllEnemies());
         }
     }
 
@@ -181,6 +182,31 @@ public class DungeonGameController : MonoBehaviour
             yield return new WaitForSeconds(spawnInterval);  // Wait before spawning the next enemy (adjust as needed)
         }
     }
+
+    IEnumerator FreezeAllEnemies(){
+        {
+            
+            GameObject[] enemies = GameObject.FindGameObjectsWithTag("Enemy"); // searches for all enemies
+            
+            if (enemies.Length > 0){
+                foreach (GameObject enemy in enemies)
+                {
+                    Debug.Log("you accidentally froze");
+                    UnityEngine.AI.NavMeshAgent enemyNavMesh = enemy.GetComponent<UnityEngine.AI.NavMeshAgent>(); // getting the navmesh. if it doesnt, this returns null and the freeze thing wont bug out (hopefully)
+                    Enemy enemyScript = enemy.GetComponent<Enemy>(); // gets the enemy script to be disabled on game over
+                    Animator animator = enemy.GetComponentInChildren<Animator>(); // the part that makes the enemy move in place. remove that too.
+                    enemyNavMesh.isStopped = true; // this should freeze all the enemies in place
+                    enemyScript.enabled = false; // stop registering attacks and playing all those sound effects
+                    animator.enabled = false; // stop moving. THE WORLD
+                }
+            } else{
+                Debug.Log("no enemies lol");
+            }
+        }
+
+        yield return 0;
+    }
+
 
     // This method is called when the player collides with the Dungeon Trigger
     private void OnTriggerEnter(Collider other)

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -210,6 +210,7 @@ namespace HomeByMarch
             {
                 Vector3 rayEnd = rayOrigin + direction * attackDistance;
                 Debug.DrawLine(rayOrigin, rayEnd, Color.red, 0.1f);
+                Debug.Log($"{rayEnd.x}, {rayEnd.y}, {rayEnd.z}");
 
                 if (Physics.Raycast(rayOrigin, direction, out RaycastHit hit, attackDistance))
                 {


### PR DESCRIPTION
Bug 1: Unable to press previous
Issue: The encircled part did not have a button component to be pressed
![image](https://github.com/user-attachments/assets/d9da258d-3bc6-4cc7-a7b8-26c7dbcce3a1)
Solution: Added button component to the PrevButton of Panels 7 and 8

Relevant Files: Assets/Scenes/Main Tutorial


Bug 2: Timer ran out but still continued
Issue: Dungeon controller code did not have the lines that made the game over screen pop up on a timeout.
Solution: Added a serializable field for the game over panel; Added in lines that made it pop up on a timeout
_Extra Stuff_: Made enemies freeze on time out as well.

Relevant Files: 
- Assets/Scripts/Dungeon Controller/Dungeon Controller.cs, line 186, function FreezeAllEnemies()
- same file as above, line 160, function EndGame(bool won)
- Assets/Scenes/Story 1-1